### PR TITLE
Add NumerAir

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ _ZK-VMs provable with Stwo._
 
 - [Stwo-Brainfuck](https://github.com/kkrt-labs/stwo-brainfuck) - A ZK-VM for the Brainfuck language, provable with Stwo.
 
+## Circuit Libraries
+
+_Libraries and utilities for building STWO based programs._
+
+- [NumerAir](https://github.com/gizatechxyz/NumerAir) - A fixed-point arithmetic library providing constrained fixed-point operations for Stwo-based circuits using M31 field elements with configurable decimal precision.
+
 ## Contributing
 
 Your contributions are always welcome! Please read the [contribution guidelines](CONTRIBUTING.md) first.


### PR DESCRIPTION
## Description

Add [NumerAir](https://github.com/gizatechxyz/NumerAir) to a new "Circuit Libraries" category. 

NumerAir is a fixed-point arithmetic library for Stwo-based circuits that provides constrained fixed-point operations using M31 field elements with configurable decimal precision. 
This addition creates a dedicated category for foundational Stwo-based circuit development tools and libraries.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New project addition
- [ ] Update to existing project
- [X] Documentation update
- [ ] Other (please describe)

## Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] The project is actively maintained
- [WIP] The project has documentation 
- [X] The project is open source
- [X] I have added the project to the appropriate category
- [X] The project description is clear and concise
- [X] All links are working
- [X] I have checked my spelling and grammar
